### PR TITLE
Prevent endless loop when adding event the DST begin day

### DIFF
--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -349,7 +349,7 @@ class DayColumn extends React.Component {
 
     while (dates.lte(current, endDate)) {
       slots.push(current)
-      current = dates.add(current, this.props.step, 'minutes')
+      current = new Date(+current + this.props.step * 60 * 1000)
     }
 
     notify(this.props.onSelectSlot, {


### PR DESCRIPTION
Replace the use of `add` but cloned the way it add instants to dates to prevent the endless loop...